### PR TITLE
Fix race condition bug.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,11 @@ export function respondJson (middleware: (request: Object, response: Object) => 
     return Promise.resolve(middleware(request, response))
     .then(
       function (value) {
-        if (response.finished) return;
+        if (response.headersSent) return;
         return response.json(value);
       },
       function (err) {
-        if (response.finished) throw err;
+        if (response.headersSent) throw err;
         next(err);
       },
     );
@@ -54,11 +54,11 @@ export function promiseMiddleware (middleware: (request: Object, response: Objec
     return bluebird.method(middleware).apply(this, [request, response])
     .then(
       function () {
-        if (response.finished) return;
+        if (response.headersSent) return;
         return next();
       },
       function (err) {
-        if (response.finished) throw err;
+        if (response.headersSent) throw err;
         next(err);
       },
     );


### PR DESCRIPTION
This module needs to handle three distinct scenarios:

Middleware initiates a response:
```js
import {promiseMiddleware} from 'express-promise-middleware';

router.get('/foo', promiseMiddleware(async function(req, res) {
  res.send('bar');
});
```

Middleware rejects:
```js
import {promiseMiddleware} from 'express-promise-middleware';

router.get('/foo', promiseMiddleware(async function(req, res) {
  throw new Error('bar');
});
```

Middleware does not initiate a response & does not reject:
```js
import {promiseMiddleware} from 'express-promise-middleware';

router.get('/foo', promiseMiddleware(async function(req, res) {
  req.user = await getUser(req.params.userId); // pretend this can't reject
});
```

In the first scenario, prior to this PR there existed a race condition where a response is initiated via `res.send` or `res.json` or `res.write` (etc.), then the middleware's promise resolves immediately, then this module's `promiseMiddleware` code runs, which checks for `res.finished`, which at this point is `false`, and determines that it should in fact call `next()`. This can lead to multiple attempts to respond to the same request and errors such as `Error: Can't set headers after they are sent.` If the response is entirely complete by the time the `promiseMiddleware` code runs, it does not call `next()` and all is well. With a large enough response payload, it is all but guaranteed that we'll hit this race condition.

The fix is simply to use `res.headersSent` instead of `res.finished`. The former is set immediately, synchronously upon the initiation of a response.

Note that middlewares wrapped in `promiseMiddleware` cannot use `next` "manually" as `next` is not passed in to them, so there are no double-`next()`-call considerations to make here.

Also everything discussed above applies equally to `respondJson`.

See also:
- a similar module that solves this problem by only calling `next()` for you if your middleware explicitly resolves to the string "next": https://github.com/express-promise-router/express-promise-router/blob/54e3d0949b4d629f43e9e72ca0c3384fc49a5b8d/lib/express-promise-router.js#L31-L47.
- [`response.finished`](https://nodejs.org/api/http.html#http_response_finished)
- [`response.headersSent`](https://nodejs.org/api/http.html#http_response_headerssent)
- [`response.headersSent` in Express docs](https://expressjs.com/en/4x/api.html#res.headersSent), showing that it gets set synchronously

cc @demands 